### PR TITLE
Hebrew

### DIFF
--- a/Lib/glyphNameFormatter/rangeProcessors/hebrew.py
+++ b/Lib/glyphNameFormatter/rangeProcessors/hebrew.py
@@ -1,15 +1,49 @@
+# Edited in March 2016 by Daniel Grumer
+# Spelling of Cantillation Marks were adjusted according to Wikipedia (https://en.wikipedia.org/wiki/Cantillation)
 
 def process(self):
-    self.replace("HEBREW LIGATURE YIDDISH DOUBLE VAV", "vav_vav")   # yiddish ?
-    self.replace("HEBREW LIGATURE YIDDISH VAV YOD", "vav_yod")  # yiddish ?
+    # Those are ligatures. They can be used for both Hebrew and Yiddish, no need for language indication. 
+    self.replace("HEBREW LIGATURE YIDDISH DOUBLE VAV", "vav_vav") 
+    self.replace("HEBREW LIGATURE YIDDISH VAV YOD", "vav_yod") 
     self.replace("HEBREW LIGATURE YIDDISH DOUBLE YOD", "yod_yod")
+    
+    # This is a change that was not created by me, but seems totally fine. I also have no idea what those marks are used for (will try to find out)
     self.replace("HEBREW MARK UPPER DOT", "dotupper")
     self.replace("HEBREW MARK LOWER DOT", "dotlower")
-    self.replace("HEBREW PUNCTUATION GERESH", "gereshpunctuation")
-    self.replace("HEBREW PUNCTUATION GERSHAYIM", "gershayimpunctuation")
-    self.replace("HEBREW ACCENT SEGOL", "segolta")
-    self.replace("HEBREW LETTER FINAL PE", "pehfinal")
-    self.replace("HEBREW LETTER PE", "peh")
+        
+    # Those are changes in spelling, to match the Ashkenazi naming as they appear in Wikipedia:
+    self.edit("ATNAH HAFUKH", "atnachHafukh")
+    self.edit("MUNAH", "munach")
+    self.edit("MAHAPAKH", "mahpach")
+    self.edit("MERKHA KEFULA", "merchaKefulah")
+    self.edit("MERKHA", "mercha")
+    self.edit("QARNEY PARA", "qarneFarah")       
+    self.edit("TELISHA GEDOLA", "telishaGedolah")
+    self.edit("TELISHA QETANA", "telishaQetannah")
+    self.edit("TIPEHA", "tifcha")
+    self.edit("YERAH BEN YOMO", "yerachBenYomo")
+    self.edit("ZINOR", "tsinnorit")                  
+    self.edit("HOLAM HASER FOR VAV", "holamHaser")
+    self.edit("DAGESH OR MAPIQ", "dagesh")
+    self.edit("MARK MASORA CIRCLE", "masoraCircle")
+
+    # Those are just adding the word-separation
+    self.edit("GERESH MUQDAM", "gereshMuqdam")
+    self.edit("ZAQEF QATAN", "zaqefQatan")
+    self.edit("ZAQEF GADOL", "zaqefGadol")
+    self.edit("SOF PASUQ", "sofPasuq")
+    self.edit("HATAF SEGOL", "hatafSegol")
+    self.edit("HATAF PATAH", "hatafPatah")
+    self.edit("HATAF QAMATS", "hatafQamats")
+    self.edit("SIN DOT", "sinDot")
+    self.edit("SHIN DOT", "shinDot")
+    self.edit("NUN HAFUKHA", "nunHafukha")
+    self.edit("QAMATS QATAN", "qamatsQatan")
+
+    # avoid multiple names
+    self.edit("ACCENT SEGOL", "segolta")                 # different name chosen to avoid multiples         
+    self.edit("ACCENT GERSHAYIM", "SheneGerishin")       # different name chosen to avoid multiples  
+    self.edit("ACCENT GERESH", "azla" )                  # different name chosen to avoid multiples    
 
     # used in alphabetic presentation forms
     self.edit("WIDE", "wide")
@@ -17,9 +51,12 @@ def process(self):
     self.edit("HEBREW LIGATURE YIDDISH YOD YOD PATAH", "yod_yod_patah")
     self.edit("ALTERNATIVE", "alt")
 
-    self.edit("ACCENT", "")
-    self.edit("FINAL", "final")    # .fina
-    self.edit("POINT", "")   # point? or nikud?
+    # cleanup
+    self.edit("POINT")          # 'Nikud' marks        Vowel-pointing system
+    self.edit("ACCENT")         # Cantillation marks   Used in religious texts, to indicate how to sing     
+    self.edit("PUNCTUATION")    # Puncutation marks    Used in religious texts (regular texts use the latin period, comma, colon etc)
+    self.edit("MARK")           # Other marks          I couldn't find what they are used for
+
     if self.has("YIDDISH"):
         if self.replace("YIDDISH"):
             self.suffix("yiddish")
@@ -29,10 +66,8 @@ def process(self):
     self.edit("HEBREW LETTER")
     self.edit('HEBREW')
     self.edit("LETTER")
-
     self.lower()
     self.compress()
-
 
 if __name__ == "__main__":
     from glyphNameFormatter.test import printRange


### PR DESCRIPTION
- Cantillation names adjusted according to Wikipedia
- segol, geresh, gershayim use alternative names to avoid multiples
- used camelCase to indicate non-obvious word space