### PR TITLE
Switch to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import re
 
 


### PR DESCRIPTION
This lets you install as develop, so you can hack on code and not have to reinstall (the old .pth days!)