### PR TITLE
Need to include non-py files in setup tools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setup(name = "Glyph Name Formatter",
               "glyphNameFormatter.test",
       ],
       package_dir = {"":"Lib"},
+      package_data = {
+              'glyphNameFormatter': ['data/*.txt', 'data/*.html', 'data/*.xml'],
+      }
 )


### PR DESCRIPTION
I think I broke this, now fixed.