### PR TITLE
This addresses issue #60.

### DIFF
--- a/Lib/glyphNameFormatter/rangeProcessors/cyrillic_supplement.py
+++ b/Lib/glyphNameFormatter/rangeProcessors/cyrillic_supplement.py
@@ -4,8 +4,14 @@ def process(self):
     # self.edit("ARMENIAN")
     # self.handleCase()
     # self.compress()
-    self.edit("REVERSED")
+    #self.edit("REVERSED")
+    if self.has("REVERSED"):
+    	self.replace("REVERSED", "reversed")
+    if self.has("MIDDLE"):
+        self.replace("MIDDLE", "middle")
+        self.edit("WITH")
     self.processAs("Cyrillic")
+    self.compress()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `reversed` part of the name was dropped during processing, which in turn pushed the regular ze and Ze out of the lists. This adds Zereversedcyr, zereversedcyr
Similar issue for `middle`, which returns Elmiddlehookcyr, elmiddlehookcyr, Enmiddlehookcyr, enmiddlehookcyr