### PR TITLE
fix NameError in U2u

### DIFF
--- a/Lib/glyphNameFormatter/reader.py
+++ b/Lib/glyphNameFormatter/reader.py
@@ -192,7 +192,7 @@ def U2u(uni):
 	lwrUni = upperToLower.get(uni)
 	if lwrUni is not None:
 		return lwrUni
-	return lwr
+	return uni
 
 if __name__ == "__main__":
 	print("upperToLower map:", len(upperToLower))


### PR DESCRIPTION
Using U2u causes the traceback below, changing `lwr` to `uni` (same as in u2U) solves this issue.
```
Traceback (most recent call last):
  File "<untitled>", line 9, in <module>
  File "/Applications/RoboFont.app/Contents/Resources/lib/python3.7/glyphNameFormatter/reader.py", line 195, in U2u
NameError: name 'lwr' is not defined
```
