### PR TITLE
rename arrowuprighttip to arrowrightuptip

### DIFF
--- a/Lib/glyphNameFormatter/rangeProcessors/arrows.py
+++ b/Lib/glyphNameFormatter/rangeProcessors/arrows.py
@@ -66,9 +66,9 @@ def process(self):
 
     self.edit("LONG", "long")
     self.edit("LEFTWARDS", "left")
-    self.edit("UPWARDS", "up")
     self.edit("OVER RIGHTWARDS", "overright")
     self.edit("RIGHTWARDS", "right")
+    self.edit("UPWARDS", "up")
     self.edit("DOWNWARDS", "down")
     self.edit("LEFT RIGHT", "leftright")
     self.edit("UP DOWN", "updown")


### PR DESCRIPTION
Previously the proposed name for `uni21B1` was `arrowuprighttip`. When looking at similar arrows in the list (see below), I think it makes sense that it is called `arrowrightuptip`. Moving line 69 to 71 in rangeProcessors/arrows.py fixes this, without causing any other changes.

Previously:
```
arrowleftuptip                                    -                             -                             21B0   ↰    UPWARDS ARROW WITH TIP LEFTWARDS
arrowuprighttip                                   -                             -                             21B1   ↱    UPWARDS ARROW WITH TIP RIGHTWARDS
arrowleftdowntip                                  -                             -                             21B2   ↲    DOWNWARDS ARROW WITH TIP LEFTWARDS
arrowrightdowntip                                 -                             -                             21B3   ↳    DOWNWARDS ARROW WITH TIP RIGHTWARDS
```

Now:
```
arrowleftuptip                                    -                             -                             21B0   ↰    UPWARDS ARROW WITH TIP LEFTWARDS
arrowrightuptip                                   -                             -                             21B1   ↱    UPWARDS ARROW WITH TIP RIGHTWARDS
arrowleftdowntip                                  -                             -                             21B2   ↲    DOWNWARDS ARROW WITH TIP LEFTWARDS
arrowrightdowntip                                 -                             -                             21B3   ↳    DOWNWARDS ARROW WITH TIP RIGHTWARDS
```