### PR TITLE
Add custom edits for commaaccent characters

### DIFF
--- a/Lib/glyphNameFormatter/rangeProcessors/latin_extended_a.py
+++ b/Lib/glyphNameFormatter/rangeProcessors/latin_extended_a.py
@@ -2,8 +2,18 @@
 def process(self):
     self.edit("LATIN")
 
+    self.edit("CAPITAL LETTER G WITH CEDILLA", "Gcommaaccent")
+    self.edit("SMALL LETTER G WITH CEDILLA", "gcommaaccent")
     self.edit("CAPITAL LETTER H WITH STROKE", "Hbar")
     self.edit("SMALL LETTER H WITH STROKE", "hbar")
+    self.edit("CAPITAL LETTER K WITH CEDILLA", "Kcommaaccent")
+    self.edit("SMALL LETTER K WITH CEDILLA", "kcommaaccent")
+    self.edit("CAPITAL LETTER L WITH CEDILLA", "Lcommaaccent")
+    self.edit("SMALL LETTER L WITH CEDILLA", "lcommaaccent")
+    self.edit("CAPITAL LETTER N WITH CEDILLA", "Ncommaaccent")
+    self.edit("SMALL LETTER N WITH CEDILLA", "ncommaaccent")
+    self.edit("CAPITAL LETTER R WITH CEDILLA", "Rcommaaccent")
+    self.edit("SMALL LETTER R WITH CEDILLA", "rcommaaccent")
     self.edit("CAPITAL LETTER T WITH STROKE", "Tbar")
     self.edit("SMALL LETTER T WITH STROKE", "tbar")
     self.edit("CAPITAL LETTER L WITH STROKE", "Lslash")

--- a/Lib/glyphNameFormatter/rangeProcessors/latin_extended_additional.py
+++ b/Lib/glyphNameFormatter/rangeProcessors/latin_extended_additional.py
@@ -3,6 +3,8 @@
 def process(self):
     self.edit("LATIN")
     # edits go here
+    self.edit("CAPITAL LETTER D WITH CEDILLA", "Dcommaaccent")
+    self.edit("SMALL LETTER D WITH CEDILLA", "dcommaaccent")
     self.replace("CAPITAL LETTER MIDDLE-WELSH LL", "LLwelsh")
 
     # self.edit("WITH DOT BELOW AND DOT ABOVE", "dotbelow", "dotaccent")


### PR DESCRIPTION
This PR addresses the points raised in #45 and intents to fix previously ambiguous (legacy) naming. Cedilla-to-commaaccent changes therefore happen for d, g, k, l, n, r, while c,e,h,s,t are left unchanged.

May also solve #97.